### PR TITLE
Texture based bump map generation API

### DIFF
--- a/assets/canvas/shaders/internal/material_main.frag
+++ b/assets/canvas/shaders/internal/material_main.frag
@@ -20,8 +20,7 @@
 #include canvas:shaders/internal/program.glsl
 #include lumi:shaders/api/pbr_vars.glsl
 #include lumi:shaders/lib/pbr.glsl
-
-#define LUMI_BUMP
+#include lumi:shaders/api/context_bump.glsl
 
 #include canvas:apitarget
 

--- a/assets/canvas/shaders/internal/material_main.frag
+++ b/assets/canvas/shaders/internal/material_main.frag
@@ -21,6 +21,8 @@
 #include lumi:shaders/api/pbr_vars.glsl
 #include lumi:shaders/lib/pbr.glsl
 
+#define LUMI_BUMP
+
 #include canvas:apitarget
 
 /******************************************************

--- a/assets/canvas/shaders/internal/material_main.vert
+++ b/assets/canvas/shaders/internal/material_main.vert
@@ -15,6 +15,11 @@
   canvas:shaders/internal/material_main.vert
 ******************************************************/
 
+#define LUMI_BUMP
+vec2 uvN;
+vec2 uvT;
+vec2 uvB;
+
 void _cv_startVertex(inout frx_VertexData data, in int cv_programId) {
 #include canvas:startvertex
 }
@@ -44,7 +49,11 @@ void main() {
 	int cv_programId = _cv_vertexProgramId();
 	_cv_startVertex(data, cv_programId);
 	
-	pbr_fragPos = data.vertex.xyz;
+	pbr_fragPos = data.vertex.xyz; 
+
+	uvN = clamp(data.spriteUV + vec2(-0.015625, 0.015625), 0.0, 1.0);
+	uvT = clamp(data.spriteUV + vec2(0.015625, 0), 0.0, 1.0);
+	uvB = clamp(data.spriteUV - vec2(0, 0.015625), 0.0, 1.0);
 
 	if (_cvu_atlas[_CV_SPRITE_INFO_TEXTURE_SIZE] != 0.0) {
 		float spriteIndex = in_material.x;
@@ -61,6 +70,10 @@ void main() {
 		spriteBounds /= vec4(atlasWidth, atlasHeight, atlasWidth, atlasHeight);
 
 		data.spriteUV = spriteBounds.xy + data.spriteUV * spriteBounds.zw;
+
+		uvN = spriteBounds.xy + uvN * spriteBounds.zw;
+		uvT = spriteBounds.xy + uvT * spriteBounds.zw;
+		uvB = spriteBounds.xy + uvB * spriteBounds.zw;
 	}
 
 	data.spriteUV = _cv_textureCoord(data.spriteUV, 0);

--- a/assets/canvas/shaders/internal/material_main.vert
+++ b/assets/canvas/shaders/internal/material_main.vert
@@ -1,3 +1,8 @@
+/*
+ * Derived from Canvas (https://github.com/grondag/canvas) material_main shader, Apache 2.0 license.
+ * Modified to add PBR varyings and support for texture-based bump map generation.
+*/
+
 #include canvas:shaders/internal/header.glsl
 #include frex:shaders/api/context.glsl
 #include canvas:shaders/internal/varying.glsl
@@ -8,12 +13,14 @@
 #include canvas:shaders/internal/diffuse.glsl
 #include canvas:shaders/internal/program.glsl
 #include lumi:shaders/api/pbr_vars.glsl
+#include lumi:shaders/api/context_bump.glsl
 
-#define LUMI_BUMP
+#ifdef LUMI_BUMP
 float bump_resolution;
 vec2 uvN;
 vec2 uvT;
 vec2 uvB;
+#endif
 
 #include canvas:apitarget
 
@@ -47,18 +54,22 @@ void main() {
 
 	_cv_setupProgram();
 
+#ifdef LUMI_BUMP
 	bump_resolution = 1.0;
+#endif
 
 	int cv_programId = _cv_vertexProgramId();
 	_cv_startVertex(data, cv_programId);
 	
 	pbr_fragPos = data.vertex.xyz; 
 
+#ifdef LUMI_BUMP
 	float bumpSample = 0.015625 * bump_resolution;
 
 	uvN = clamp(data.spriteUV + vec2(-bumpSample, bumpSample), 0.0, 1.0);
 	uvT = clamp(data.spriteUV + vec2(bumpSample, 0), 0.0, 1.0);
 	uvB = clamp(data.spriteUV - vec2(0, bumpSample), 0.0, 1.0);
+#endif
 
 	if (_cvu_atlas[_CV_SPRITE_INFO_TEXTURE_SIZE] != 0.0) {
 		float spriteIndex = in_material.x;
@@ -76,9 +87,11 @@ void main() {
 
 		data.spriteUV = spriteBounds.xy + data.spriteUV * spriteBounds.zw;
 
+#ifdef LUMI_BUMP
 		uvN = spriteBounds.xy + uvN * spriteBounds.zw;
 		uvT = spriteBounds.xy + uvT * spriteBounds.zw;
 		uvB = spriteBounds.xy + uvB * spriteBounds.zw;
+#endif
 	}
 
 	data.spriteUV = _cv_textureCoord(data.spriteUV, 0);

--- a/assets/canvas/shaders/internal/material_main.vert
+++ b/assets/canvas/shaders/internal/material_main.vert
@@ -1,7 +1,8 @@
 /*
  * Derived from Canvas (https://github.com/grondag/canvas) material_main shader, Apache 2.0 license.
  * Modified to add PBR varyings and support for texture-based bump map generation.
-*/
+ * The modifications are released under the same license as Lumi Lights. See `README.MD` for license notice.
+ */
 
 #include canvas:shaders/internal/header.glsl
 #include frex:shaders/api/context.glsl

--- a/assets/canvas/shaders/internal/material_main.vert
+++ b/assets/canvas/shaders/internal/material_main.vert
@@ -9,17 +9,17 @@
 #include canvas:shaders/internal/program.glsl
 #include lumi:shaders/api/pbr_vars.glsl
 
-#include canvas:apitarget
-
-/******************************************************
-  canvas:shaders/internal/material_main.vert
-******************************************************/
-
 #define LUMI_BUMP
 float bump_resolution;
 vec2 uvN;
 vec2 uvT;
 vec2 uvB;
+
+#include canvas:apitarget
+
+/******************************************************
+  canvas:shaders/internal/material_main.vert
+******************************************************/
 
 void _cv_startVertex(inout frx_VertexData data, in int cv_programId) {
 #include canvas:startvertex

--- a/assets/canvas/shaders/internal/material_main.vert
+++ b/assets/canvas/shaders/internal/material_main.vert
@@ -16,6 +16,7 @@
 ******************************************************/
 
 #define LUMI_BUMP
+float bump_resolution;
 vec2 uvN;
 vec2 uvT;
 vec2 uvB;
@@ -46,14 +47,18 @@ void main() {
 
 	_cv_setupProgram();
 
+	bump_resolution = 1.0;
+
 	int cv_programId = _cv_vertexProgramId();
 	_cv_startVertex(data, cv_programId);
 	
 	pbr_fragPos = data.vertex.xyz; 
 
-	uvN = clamp(data.spriteUV + vec2(-0.015625, 0.015625), 0.0, 1.0);
-	uvT = clamp(data.spriteUV + vec2(0.015625, 0), 0.0, 1.0);
-	uvB = clamp(data.spriteUV - vec2(0, 0.015625), 0.0, 1.0);
+	float bumpSample = 0.015625 * bump_resolution;
+
+	uvN = clamp(data.spriteUV + vec2(-bumpSample, bumpSample), 0.0, 1.0);
+	uvT = clamp(data.spriteUV + vec2(bumpSample, 0), 0.0, 1.0);
+	uvB = clamp(data.spriteUV - vec2(0, bumpSample), 0.0, 1.0);
 
 	if (_cvu_atlas[_CV_SPRITE_INFO_TEXTURE_SIZE] != 0.0) {
 		float spriteIndex = in_material.x;

--- a/assets/lumi/shaders/lib/bump.glsl
+++ b/assets/lumi/shaders/lib/bump.glsl
@@ -24,7 +24,7 @@ vec3 _bump_bitangentMove(vec3 normal, vec3 tangent)
 
 float _bump_height(float raw)
 {
-    return frx_smootherstep(0,1,raw*raw);
+    return frx_smootherstep(0, 1, pow(raw, 1 + raw * raw));
 }
 
 vec3 bump_normal(sampler2D tex, vec3 normal, vec2 uvn, vec2 uvt, vec2 uvb)

--- a/assets/lumi/shaders/lib/bump.glsl
+++ b/assets/lumi/shaders/lib/bump.glsl
@@ -1,0 +1,40 @@
+vec3 _bump_tangentMove(vec3 normal)
+{
+    if(normal. y < 0.5 && normal.y > -0.5){
+       // Side
+       return (
+           mat4(0,  0,  -1, 0,
+                0,  1,  0,  0,
+                1,  0,  0,  0,
+                0,  0,  0,  1
+                ) * vec4(normal, 0.0)).xyz;
+    } else {
+        return (normal.y > 0.5)
+        // Top
+        ? vec3(1, 0, 0)
+        // Bottom
+        : vec3(1, 0, 0);
+    }
+}
+
+vec3 _bump_bitangentMove(vec3 normal, vec3 tangent)
+{
+    return cross(normal, tangent);
+}
+
+float _bump_height(float raw)
+{
+    return frx_smootherstep(0,1,raw);
+}
+
+vec3 bump_normal(sampler2D tex, vec3 normal, vec2 uvn, vec2 uvt, vec2 uvb)
+{
+    vec3 tangentMove = _bump_tangentMove(normal);
+    vec3 bitangentMove = _bump_bitangentMove(normal, tangentMove);
+
+    vec3 origin = _bump_height(frx_luminance(texture2D(tex, uvn, _cv_getFlag(_CV_FLAG_UNMIPPED) * -4.0).rgb))*normal;
+    vec3 tangent = tangentMove + _bump_height(frx_luminance(texture2D(tex, uvt, _cv_getFlag(_CV_FLAG_UNMIPPED) * -4.0).rgb))*normal - origin;
+    vec3 bitangent = bitangentMove + _bump_height(frx_luminance(texture2D(tex, uvb, _cv_getFlag(_CV_FLAG_UNMIPPED) * -4.0).rgb))*normal - origin;
+
+    return normalize(cross(tangent, bitangent));
+}

--- a/assets/lumi/shaders/lib/bump.glsl
+++ b/assets/lumi/shaders/lib/bump.glsl
@@ -24,7 +24,7 @@ vec3 _bump_bitangentMove(vec3 normal, vec3 tangent)
 
 float _bump_height(float raw)
 {
-    return frx_smootherstep(0,1,raw);
+    return frx_smootherstep(0,1,raw*raw);
 }
 
 vec3 bump_normal(sampler2D tex, vec3 normal, vec2 uvn, vec2 uvt, vec2 uvb)


### PR DESCRIPTION
Adds a texture based bump map generation. Light and dark texels corresponds to positive and negative bumps respectively.

The API works by performing neighboring texels UV calculation in the base vertex shader, but only when `LUMI_BUMP` context is defined in `lumi:shaders/api/context_bump.glsl` which is provided by the requesting shader packs. The result of the calculation are stored in global variables which the requesting vertex shader must then convey to the fragment shader through `varying`s of its responsibility. The fragment shader may then apply the new microfacet normal through the function provided in `lumi:shaders/lib/bump.glsl` or a derivative thereof.