### PR TITLE
Corrects handheld light

### DIFF
--- a/assets/minecraft/lights/item/glowstone.json
+++ b/assets/minecraft/lights/item/glowstone.json
@@ -1,7 +1,7 @@
 {
-    "intensity": 1.3,
-    "red": 2,
-    "green": 1.75,
-    "blue": 1.5,
-    "worksInFluid": true
+  "intensity": 1.0,
+  "red": 1.0,
+  "green": 0.875,
+  "blue": 0.75,
+  "worksInFluid": true
 }

--- a/assets/minecraft/lights/item/glowstone.json
+++ b/assets/minecraft/lights/item/glowstone.json
@@ -1,0 +1,7 @@
+{
+    "intensity": 1.3,
+    "red": 2,
+    "green": 1.75,
+    "blue": 1.5,
+    "worksInFluid": true
+}

--- a/assets/minecraft/lights/item/jack_o_lantern.json
+++ b/assets/minecraft/lights/item/jack_o_lantern.json
@@ -1,0 +1,7 @@
+{
+    "intensity": 1.3,
+    "red": 2,
+    "green": 1.75,
+    "blue": 1.5,
+    "worksInFluid": false
+}

--- a/assets/minecraft/lights/item/jack_o_lantern.json
+++ b/assets/minecraft/lights/item/jack_o_lantern.json
@@ -1,7 +1,8 @@
 {
-    "intensity": 1.3,
-    "red": 2,
-    "green": 1.75,
-    "blue": 1.5,
-    "worksInFluid": false
+  "intensity": 0.93,
+  "red": 1.0,
+  "green": 0.875,
+  "blue": 0.75,
+  "worksInFluid": false
 }
+

--- a/assets/minecraft/lights/item/lantern.json
+++ b/assets/minecraft/lights/item/lantern.json
@@ -1,0 +1,7 @@
+{
+    "intensity": 1.3,
+    "red": 2,
+    "green": 1.75,
+    "blue": 1.5,
+    "worksInFluid": false
+}

--- a/assets/minecraft/lights/item/lantern.json
+++ b/assets/minecraft/lights/item/lantern.json
@@ -1,7 +1,7 @@
 {
-    "intensity": 1.3,
-    "red": 2,
-    "green": 1.75,
-    "blue": 1.5,
-    "worksInFluid": false
+  "intensity": 0.93,
+  "red": 1.0,
+  "green": 0.875,
+  "blue": 0.75,
+  "worksInFluid": false
 }

--- a/assets/minecraft/lights/item/shroomlight.json
+++ b/assets/minecraft/lights/item/shroomlight.json
@@ -1,0 +1,7 @@
+{
+    "intensity": 1.3,
+    "red": 2,
+    "green": 1.75,
+    "blue": 1.5,
+    "worksInFluid": true
+}

--- a/assets/minecraft/lights/item/shroomlight.json
+++ b/assets/minecraft/lights/item/shroomlight.json
@@ -1,7 +1,8 @@
 {
-    "intensity": 1.3,
-    "red": 2,
-    "green": 1.75,
-    "blue": 1.5,
-    "worksInFluid": true
+  "intensity": 1.0,
+  "red": 1.0,
+  "green": 0.875,
+  "blue": 0.75,
+  "worksInFluid": true
 }
+

--- a/assets/minecraft/lights/item/torch.json
+++ b/assets/minecraft/lights/item/torch.json
@@ -1,0 +1,7 @@
+{
+    "intensity": 1.2,
+    "red": 1.85,
+    "green": 1.65,
+    "blue": 1.4,
+    "worksInFluid": false
+}

--- a/assets/minecraft/lights/item/torch.json
+++ b/assets/minecraft/lights/item/torch.json
@@ -1,7 +1,8 @@
 {
-    "intensity": 1.2,
-    "red": 1.85,
-    "green": 1.65,
-    "blue": 1.4,
-    "worksInFluid": false
+  "intensity": 0.93,
+  "red": 1.0,
+  "green": 0.875,
+  "blue": 0.75,
+  "worksInFluid": false
 }
+


### PR DESCRIPTION
Makes handheld light color match with actual light color of torch, jack o lantern, lantern, and glowstone.

Didn't do the other ones because theyre colored and/or don't emit light normally